### PR TITLE
Use pytest fixture to ease tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -105,7 +105,7 @@ VALID_HTTPS = True
 VALID_VERIFY_SSL = True
 VALID_USER = "valid_user"
 VALID_USER_2SA = "valid_user_2sa"
-VALID_PASSWORD = "valid_password"
+VALID_PASSWORD = "valid_password"  # noqa: S105
 VALID_OTP = "123456"
 
 USER_MAX_TRY = "user_max"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Main conftest."""
+import pytest
+
+from . import SynologyDSMMock
+from . import VALID_HOST
+from . import VALID_HTTPS
+from . import VALID_PASSWORD
+from . import VALID_PORT
+from . import VALID_USER
+from . import VALID_VERIFY_SSL
+from synology_dsm.synology_dsm import SynologyDSM
+
+
+@pytest.fixture
+def api() -> SynologyDSM:
+    """Return a mock DSM API."""
+    return SynologyDSMMock(
+        VALID_HOST,
+        VALID_PORT,
+        VALID_USER,
+        VALID_PASSWORD,
+        VALID_HTTPS,
+        VALID_VERIFY_SSL,
+    )
+
+
+@pytest.fixture
+def dsm(api) -> SynologyDSM:
+    """Alias for api fixture."""
+    return api
+
+
+@pytest.fixture
+def dsm_5(api) -> SynologyDSM:
+    """Return a mock DSM 5 API."""
+    api.dsm_version = 5
+    return api

--- a/tests/const.py
+++ b/tests/const.py
@@ -6,8 +6,8 @@
 # if data failed, add "_FAILED"
 
 SESSION_ID = "session_id"
-SYNO_TOKEN = "Syñ0_T0k€ñ"
-DEVICE_TOKEN = "Dév!cè_T0k€ñ"
+SYNO_TOKEN = "Syñ0_T0k€ñ"  # noqa: S105
+DEVICE_TOKEN = "Dév!cè_T0k€ñ"  # noqa: S105
 UNIQUE_KEY = "1x2X3x!_UK"
 
 # Common API error code

--- a/tests/test_synology_dsm.py
+++ b/tests/test_synology_dsm.py
@@ -1,6 +1,4 @@
 """Synology DSM tests."""
-from unittest import TestCase
-
 import pytest
 
 from . import SynologyDSMMock
@@ -29,34 +27,21 @@ from synology_dsm.exceptions import SynologyDSMLoginInvalidException
 from synology_dsm.exceptions import SynologyDSMRequestException
 
 
-class TestSynologyDSM(TestCase):
+class TestSynologyDSM:
     """SynologyDSM test cases."""
 
-    api = None
-
-    def setUp(self):
-        """Context initialisation called for all tests."""
-        self.api = SynologyDSMMock(
-            VALID_HOST,
-            VALID_PORT,
-            VALID_USER,
-            VALID_PASSWORD,
-            VALID_HTTPS,
-            VALID_VERIFY_SSL,
-        )
-
-    def test_init(self):
+    def test_init(self, dsm):
         """Test init."""
-        assert self.api.username
-        assert self.api._base_url
-        assert self.api._timeout == 10
-        assert not self.api.apis.get(API_AUTH)
-        assert not self.api._session_id
+        assert dsm.username
+        assert dsm._base_url
+        assert dsm._timeout == 10
+        assert not dsm.apis.get(API_AUTH)
+        assert not dsm._session_id
 
-    def test_connection_failed(self):
+    def test_connection_failed(self, dsm):
         """Test failed connection."""
         # No internet
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             "no_internet",
             VALID_PORT,
             VALID_USER,
@@ -65,7 +50,7 @@ class TestSynologyDSM(TestCase):
             VALID_VERIFY_SSL,
         )
         with pytest.raises(SynologyDSMRequestException) as error:
-            api.login()
+            dsm.login()
         error_value = error.value.args[0]
         assert not error_value["api"]
         assert error_value["code"] == -1
@@ -75,11 +60,11 @@ class TestSynologyDSM(TestCase):
             in error_value["details"]
         )
 
-        assert not api.apis.get(API_AUTH)
-        assert not api._session_id
+        assert not dsm.apis.get(API_AUTH)
+        assert not dsm._session_id
 
         # Wrong host
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             "host",
             VALID_PORT,
             VALID_USER,
@@ -88,7 +73,7 @@ class TestSynologyDSM(TestCase):
             VALID_VERIFY_SSL,
         )
         with pytest.raises(SynologyDSMRequestException) as error:
-            api.login()
+            dsm.login()
         error_value = error.value.args[0]
         assert not error_value["api"]
         assert error_value["code"] == -1
@@ -98,15 +83,15 @@ class TestSynologyDSM(TestCase):
             in error_value["details"]
         )
 
-        assert not api.apis.get(API_AUTH)
-        assert not api._session_id
+        assert not dsm.apis.get(API_AUTH)
+        assert not dsm._session_id
 
         # Wrong port
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             VALID_HOST, 0, VALID_USER, VALID_PASSWORD, VALID_HTTPS, VALID_VERIFY_SSL
         )
         with pytest.raises(SynologyDSMRequestException) as error:
-            api.login()
+            dsm.login()
         error_value = error.value.args[0]
         assert not error_value["api"]
         assert error_value["code"] == -1
@@ -116,11 +101,11 @@ class TestSynologyDSM(TestCase):
             "wrong version number (_ssl.c:1076)"
         )
 
-        assert not api.apis.get(API_AUTH)
-        assert not api._session_id
+        assert not dsm.apis.get(API_AUTH)
+        assert not dsm._session_id
 
         # Wrong HTTPS
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER,
@@ -129,18 +114,18 @@ class TestSynologyDSM(TestCase):
             VALID_VERIFY_SSL,
         )
         with pytest.raises(SynologyDSMRequestException) as error:
-            api.login()
+            dsm.login()
         error_value = error.value.args[0]
         assert not error_value["api"]
         assert error_value["code"] == -1
         assert error_value["reason"] == "Unknown"
         assert error_value["details"] == "RequestException = Bad request"
 
-        assert not api.apis.get(API_AUTH)
-        assert not api._session_id
+        assert not dsm.apis.get(API_AUTH)
+        assert not dsm._session_id
 
         # Wrong SSL
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER,
@@ -149,7 +134,7 @@ class TestSynologyDSM(TestCase):
             False,
         )
         with pytest.raises(SynologyDSMRequestException) as error:
-            api.login()
+            dsm.login()
         error_value = error.value.args[0]
         assert not error_value["api"]
         assert error_value["code"] == -1
@@ -159,19 +144,19 @@ class TestSynologyDSM(TestCase):
             == f"SSLError = hostname '192.168.0.35' doesn't match '{VALID_HOST}'"
         )
 
-        assert not api.apis.get(API_AUTH)
-        assert not api._session_id
+        assert not dsm.apis.get(API_AUTH)
+        assert not dsm._session_id
 
-    def test_login(self):
+    def test_login(self, dsm):
         """Test login."""
-        assert self.api.login()
-        assert self.api.apis.get(API_AUTH)
-        assert self.api._session_id == SESSION_ID
-        assert self.api._syno_token == SYNO_TOKEN
+        assert dsm.login()
+        assert dsm.apis.get(API_AUTH)
+        assert dsm._session_id == SESSION_ID
+        assert dsm._syno_token == SYNO_TOKEN
 
     def test_login_failed(self):
         """Test failed login."""
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             "user",
@@ -180,17 +165,17 @@ class TestSynologyDSM(TestCase):
             VALID_VERIFY_SSL,
         )
         with pytest.raises(SynologyDSMLoginInvalidException) as error:
-            api.login()
+            dsm.login()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 400
         assert error_value["reason"] == "Invalid credentials"
         assert error_value["details"] == "Invalid password or not admin account: user"
 
-        assert api.apis.get(API_AUTH)
-        assert not api._session_id
+        assert dsm.apis.get(API_AUTH)
+        assert not dsm._session_id
 
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER,
@@ -199,7 +184,7 @@ class TestSynologyDSM(TestCase):
             VALID_VERIFY_SSL,
         )
         with pytest.raises(SynologyDSMLoginInvalidException) as error:
-            api.login()
+            dsm.login()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 400
@@ -209,12 +194,12 @@ class TestSynologyDSM(TestCase):
             == "Invalid password or not admin account: valid_user"
         )
 
-        assert api.apis.get(API_AUTH)
-        assert not api._session_id
+        assert dsm.apis.get(API_AUTH)
+        assert not dsm._session_id
 
     def test_login_2sa(self):
         """Test login with 2SA."""
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
@@ -224,7 +209,7 @@ class TestSynologyDSM(TestCase):
         )
 
         with pytest.raises(SynologyDSMLogin2SARequiredException) as error:
-            api.login()
+            dsm.login()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 403
@@ -234,16 +219,16 @@ class TestSynologyDSM(TestCase):
             == "Two-step authentication required for account: valid_user_2sa"
         )
 
-        assert api.login(VALID_OTP)
+        assert dsm.login(VALID_OTP)
 
-        assert api._session_id == SESSION_ID
-        assert api._syno_token == SYNO_TOKEN
-        assert api._device_token == DEVICE_TOKEN
-        assert api.device_token == DEVICE_TOKEN
+        assert dsm._session_id == SESSION_ID
+        assert dsm._syno_token == SYNO_TOKEN
+        assert dsm._device_token == DEVICE_TOKEN
+        assert dsm.device_token == DEVICE_TOKEN
 
     def test_login_2sa_new_session(self):
         """Test login with 2SA and a new session with granted device."""
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
@@ -252,16 +237,16 @@ class TestSynologyDSM(TestCase):
             VALID_VERIFY_SSL,
             device_token=DEVICE_TOKEN,
         )
-        assert api.login()
+        assert dsm.login()
 
-        assert api._session_id == SESSION_ID
-        assert api._syno_token == SYNO_TOKEN
-        assert api._device_token == DEVICE_TOKEN
-        assert api.device_token == DEVICE_TOKEN
+        assert dsm._session_id == SESSION_ID
+        assert dsm._syno_token == SYNO_TOKEN
+        assert dsm._device_token == DEVICE_TOKEN
+        assert dsm.device_token == DEVICE_TOKEN
 
     def test_login_2sa_failed(self):
         """Test failed login with 2SA."""
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
@@ -271,7 +256,7 @@ class TestSynologyDSM(TestCase):
         )
 
         with pytest.raises(SynologyDSMLogin2SARequiredException) as error:
-            api.login()
+            dsm.login()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 403
@@ -282,7 +267,7 @@ class TestSynologyDSM(TestCase):
         )
 
         with pytest.raises(SynologyDSMLogin2SAFailedException) as error:
-            api.login(888888)
+            dsm.login(888888)
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 404
@@ -292,13 +277,13 @@ class TestSynologyDSM(TestCase):
             == "Two-step authentication failed, retry with a new pass code"
         )
 
-        assert api._session_id is None
-        assert api._syno_token is None
-        assert api._device_token is None
+        assert dsm._session_id is None
+        assert dsm._syno_token is None
+        assert dsm._device_token is None
 
     def test_login_basic_failed(self):
         """Test basic failed login."""
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             USER_MAX_TRY,
@@ -308,7 +293,7 @@ class TestSynologyDSM(TestCase):
         )
 
         with pytest.raises(SynologyDSMLoginFailedException) as error:
-            api.login()
+            dsm.login()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.API.Auth"
         assert error_value["code"] == 407
@@ -317,7 +302,7 @@ class TestSynologyDSM(TestCase):
 
     def test_request_timeout(self):
         """Test request timeout."""
-        api = SynologyDSMMock(
+        dsm = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER,
@@ -326,19 +311,19 @@ class TestSynologyDSM(TestCase):
             VALID_VERIFY_SSL,
             timeout=2,
         )
-        assert api._timeout == 2
+        assert dsm._timeout == 2
 
-    def test_request_get(self):
+    def test_request_get(self, dsm):
         """Test get request."""
-        assert self.api.get(API_INFO, "query")
-        assert self.api.get(API_AUTH, "login")
-        assert self.api.get("SYNO.DownloadStation2.Task", "list")
-        assert self.api.get(API_AUTH, "logout")
+        assert dsm.get(API_INFO, "query")
+        assert dsm.get(API_AUTH, "login")
+        assert dsm.get("SYNO.DownloadStation2.Task", "list")
+        assert dsm.get(API_AUTH, "logout")
 
-    def test_request_get_failed(self):
+    def test_request_get_failed(self, dsm):
         """Test failed get request."""
         with pytest.raises(SynologyDSMAPINotExistsException) as error:
-            self.api.get("SYNO.Virtualization.API.Task.Info", "list")
+            dsm.get("SYNO.Virtualization.API.Task.Info", "list")
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.Virtualization.API.Task.Info"
         assert error_value["code"] == -2
@@ -348,16 +333,16 @@ class TestSynologyDSM(TestCase):
             == "API SYNO.Virtualization.API.Task.Info does not exists"
         )
 
-    def test_request_post(self):
+    def test_request_post(self, dsm):
         """Test post request."""
-        assert self.api.post(
+        assert dsm.post(
             "SYNO.FileStation.Upload",
             "upload",
             params={"dest_folder_path": "/upload/test", "create_parents": True},
             files={"file": "open('file.txt','rb')"},
         )
 
-        assert self.api.post(
+        assert dsm.post(
             "SYNO.DownloadStation2.Task",
             "create",
             params={
@@ -367,10 +352,10 @@ class TestSynologyDSM(TestCase):
             },
         )
 
-    def test_request_post_failed(self):
+    def test_request_post_failed(self, dsm):
         """Test failed post request."""
         with pytest.raises(SynologyDSMAPIErrorException) as error:
-            self.api.post(
+            dsm.post(
                 "SYNO.FileStation.Upload",
                 "upload",
                 params={"dest_folder_path": "/upload/test", "create_parents": True},
@@ -386,7 +371,7 @@ class TestSynologyDSM(TestCase):
         assert not error_value["details"]
 
         with pytest.raises(SynologyDSMAPIErrorException) as error:
-            self.api.post(
+            dsm.post(
                 "SYNO.DownloadStation2.Task",
                 "create",
                 params={
@@ -401,168 +386,165 @@ class TestSynologyDSM(TestCase):
         assert error_value["reason"] == "File does not exist"
         assert not error_value["details"]
 
-    def test_reset_str_attr(self):
+    def test_reset_str_attr(self, dsm):
         """Test reset with string attr."""
-        assert not self.api._security
-        assert self.api.security
-        assert self.api._security
-        assert self.api.reset("security")
-        assert not self.api._security
+        assert not dsm._security
+        assert dsm.security
+        assert dsm._security
+        assert dsm.reset("security")
+        assert not dsm._security
 
-    def test_reset_str_key(self):
+    def test_reset_str_key(self, dsm):
         """Test reset with string API key."""
-        assert not self.api._security
-        assert self.api.security
-        assert self.api._security
-        assert self.api.reset(SynoCoreSecurity.API_KEY)
-        assert not self.api._security
+        assert not dsm._security
+        assert dsm.security
+        assert dsm._security
+        assert dsm.reset(SynoCoreSecurity.API_KEY)
+        assert not dsm._security
 
-    def test_reset_object(self):
+    def test_reset_object(self, dsm):
         """Test reset with object."""
-        assert not self.api._security
-        assert self.api.security
-        assert self.api._security
-        assert self.api.reset(self.api.security)
-        assert not self.api._security
+        assert not dsm._security
+        assert dsm.security
+        assert dsm._security
+        assert dsm.reset(dsm.security)
+        assert not dsm._security
 
-    def test_reset_str_attr_information(self):
+    def test_reset_str_attr_information(self, dsm):
         """Test reset with string information attr (should not be reset)."""
-        assert not self.api._information
-        assert self.api.information
-        assert self.api._information
-        assert not self.api.reset("information")
-        assert self.api._information
+        assert not dsm._information
+        assert dsm.information
+        assert dsm._information
+        assert not dsm.reset("information")
+        assert dsm._information
 
-    def test_reset_str_key_information(self):
+    def test_reset_str_key_information(self, dsm):
         """Test reset with string information API key (should not be reset)."""
-        assert not self.api._information
-        assert self.api.information
-        assert self.api._information
-        assert not self.api.reset(SynoDSMInformation.API_KEY)
-        assert self.api._information
+        assert not dsm._information
+        assert dsm.information
+        assert dsm._information
+        assert not dsm.reset(SynoDSMInformation.API_KEY)
+        assert dsm._information
 
-    def test_reset_object_information(self):
+    def test_reset_object_information(self, dsm):
         """Test reset with information object (should not be reset)."""
-        assert not self.api._information
-        assert self.api.information
-        assert self.api._information
-        assert not self.api.reset(self.api.information)
-        assert self.api._information
+        assert not dsm._information
+        assert dsm.information
+        assert dsm._information
+        assert not dsm.reset(dsm.information)
+        assert dsm._information
 
-    def test_information(self):
+    def test_information(self, dsm):
         """Test information."""
-        assert self.api.information
-        self.api.information.update()
-        assert self.api.information.model == "DS918+"
-        assert self.api.information.ram == 4096
-        assert self.api.information.serial == "1920PDN001501"
-        assert self.api.information.temperature == 40
-        assert not self.api.information.temperature_warn
-        assert self.api.information.uptime == 155084
-        assert self.api.information.version == "24922"
-        assert self.api.information.version_string == "DSM 6.2.2-24922 Update 4"
+        assert dsm.information
+        dsm.information.update()
+        assert dsm.information.model == "DS918+"
+        assert dsm.information.ram == 4096
+        assert dsm.information.serial == "1920PDN001501"
+        assert dsm.information.temperature == 40
+        assert not dsm.information.temperature_warn
+        assert dsm.information.uptime == 155084
+        assert dsm.information.version == "24922"
+        assert dsm.information.version_string == "DSM 6.2.2-24922 Update 4"
 
-    def test_network(self):
+    def test_network(self, dsm):
         """Test network."""
-        assert self.api.network
-        self.api.network.update()
-        assert self.api.network.dns
-        assert self.api.network.gateway
-        assert self.api.network.hostname
-        assert self.api.network.interfaces
-        assert self.api.network.interface("eth0")
-        assert self.api.network.interface("eth1")
-        assert self.api.network.macs
-        assert self.api.network.workgroup
+        assert dsm.network
+        dsm.network.update()
+        assert dsm.network.dns
+        assert dsm.network.gateway
+        assert dsm.network.hostname
+        assert dsm.network.interfaces
+        assert dsm.network.interface("eth0")
+        assert dsm.network.interface("eth1")
+        assert dsm.network.macs
+        assert dsm.network.workgroup
 
-    def test_security(self):
+    def test_security(self, dsm):
         """Test security, safe status."""
-        assert self.api.security
-        self.api.security.update()
-        assert self.api.security.checks
-        assert self.api.security.last_scan_time
-        assert not self.api.security.start_time  # Finished scan
-        assert self.api.security.success
-        assert self.api.security.progress
-        assert self.api.security.status == "safe"
-        assert self.api.security.status_by_check
-        assert self.api.security.status_by_check["malware"] == "safe"
-        assert self.api.security.status_by_check["network"] == "safe"
-        assert self.api.security.status_by_check["securitySetting"] == "safe"
-        assert self.api.security.status_by_check["systemCheck"] == "safe"
-        assert self.api.security.status_by_check["update"] == "safe"
-        assert self.api.security.status_by_check["userInfo"] == "safe"
+        assert dsm.security
+        dsm.security.update()
+        assert dsm.security.checks
+        assert dsm.security.last_scan_time
+        assert not dsm.security.start_time  # Finished scan
+        assert dsm.security.success
+        assert dsm.security.progress
+        assert dsm.security.status == "safe"
+        assert dsm.security.status_by_check
+        assert dsm.security.status_by_check["malware"] == "safe"
+        assert dsm.security.status_by_check["network"] == "safe"
+        assert dsm.security.status_by_check["securitySetting"] == "safe"
+        assert dsm.security.status_by_check["systemCheck"] == "safe"
+        assert dsm.security.status_by_check["update"] == "safe"
+        assert dsm.security.status_by_check["userInfo"] == "safe"
 
-    def test_security_error(self):
+    def test_security_error(self, dsm):
         """Test security, outOfDate status."""
-        self.api.error = True
-        assert self.api.security
-        self.api.security.update()
-        assert self.api.security.checks
-        assert self.api.security.last_scan_time
-        assert not self.api.security.start_time  # Finished scan
-        assert self.api.security.success
-        assert self.api.security.progress
-        assert self.api.security.status == "outOfDate"
-        assert self.api.security.status_by_check
-        assert self.api.security.status_by_check["malware"] == "safe"
-        assert self.api.security.status_by_check["network"] == "safe"
-        assert self.api.security.status_by_check["securitySetting"] == "safe"
-        assert self.api.security.status_by_check["systemCheck"] == "safe"
-        assert self.api.security.status_by_check["update"] == "outOfDate"
-        assert self.api.security.status_by_check["userInfo"] == "safe"
+        dsm.error = True
+        assert dsm.security
+        dsm.security.update()
+        assert dsm.security.checks
+        assert dsm.security.last_scan_time
+        assert not dsm.security.start_time  # Finished scan
+        assert dsm.security.success
+        assert dsm.security.progress
+        assert dsm.security.status == "outOfDate"
+        assert dsm.security.status_by_check
+        assert dsm.security.status_by_check["malware"] == "safe"
+        assert dsm.security.status_by_check["network"] == "safe"
+        assert dsm.security.status_by_check["securitySetting"] == "safe"
+        assert dsm.security.status_by_check["systemCheck"] == "safe"
+        assert dsm.security.status_by_check["update"] == "outOfDate"
+        assert dsm.security.status_by_check["userInfo"] == "safe"
 
-    def test_shares(self):
+    def test_shares(self, dsm):
         """Test shares."""
-        assert self.api.share
-        self.api.share.update()
-        assert self.api.share.shares
-        for share_uuid in self.api.share.shares_uuids:
-            assert self.api.share.share_name(share_uuid)
-            assert self.api.share.share_path(share_uuid)
-            assert self.api.share.share_recycle_bin(share_uuid) is not None
-            assert self.api.share.share_size(share_uuid) is not None
-            assert self.api.share.share_size(share_uuid, human_readable=True)
+        assert dsm.share
+        dsm.share.update()
+        assert dsm.share.shares
+        for share_uuid in dsm.share.shares_uuids:
+            assert dsm.share.share_name(share_uuid)
+            assert dsm.share.share_path(share_uuid)
+            assert dsm.share.share_recycle_bin(share_uuid) is not None
+            assert dsm.share.share_size(share_uuid) is not None
+            assert dsm.share.share_size(share_uuid, human_readable=True)
 
         assert (
-            self.api.share.share_name("2ee6c06a-8766-48b5-013d-63b18652a393")
-            == "test_share"
+            dsm.share.share_name("2ee6c06a-8766-48b5-013d-63b18652a393") == "test_share"
         )
         assert (
-            self.api.share.share_path("2ee6c06a-8766-48b5-013d-63b18652a393")
-            == "/volume1"
+            dsm.share.share_path("2ee6c06a-8766-48b5-013d-63b18652a393") == "/volume1"
         )
         assert (
-            self.api.share.share_recycle_bin("2ee6c06a-8766-48b5-013d-63b18652a393")
-            is True
+            dsm.share.share_recycle_bin("2ee6c06a-8766-48b5-013d-63b18652a393") is True
         )
         assert (
-            self.api.share.share_size("2ee6c06a-8766-48b5-013d-63b18652a393")
+            dsm.share.share_size("2ee6c06a-8766-48b5-013d-63b18652a393")
             == 3.790251876432216e19
         )
         assert (
-            self.api.share.share_size("2ee6c06a-8766-48b5-013d-63b18652a393", True)
+            dsm.share.share_size("2ee6c06a-8766-48b5-013d-63b18652a393", True)
             == "32.9Eb"
         )
 
-    def test_system(self):
+    def test_system(self, dsm):
         """Test system."""
-        assert self.api.system
-        self.api.system.update()
-        assert self.api.system.cpu_clock_speed
-        assert self.api.system.cpu_cores
-        assert self.api.system.cpu_family
-        assert self.api.system.cpu_series
-        assert self.api.system.firmware_ver
-        assert self.api.system.model
-        assert self.api.system.ram_size
-        assert self.api.system.serial
-        assert self.api.system.sys_temp
-        assert self.api.system.time
-        assert self.api.system.time_zone
-        assert self.api.system.time_zone_desc
-        assert self.api.system.up_time
-        for usb_dev in self.api.system.usb_dev:
+        assert dsm.system
+        dsm.system.update()
+        assert dsm.system.cpu_clock_speed
+        assert dsm.system.cpu_cores
+        assert dsm.system.cpu_family
+        assert dsm.system.cpu_series
+        assert dsm.system.firmware_ver
+        assert dsm.system.model
+        assert dsm.system.ram_size
+        assert dsm.system.serial
+        assert dsm.system.sys_temp
+        assert dsm.system.time
+        assert dsm.system.time_zone
+        assert dsm.system.time_zone_desc
+        assert dsm.system.up_time
+        for usb_dev in dsm.system.usb_dev:
             assert usb_dev.get("cls")
             assert usb_dev.get("pid")
             assert usb_dev.get("producer")
@@ -570,25 +552,25 @@ class TestSynologyDSM(TestCase):
             assert usb_dev.get("rev")
             assert usb_dev.get("vid")
 
-    def test_upgrade(self):
+    def test_upgrade(self, dsm):
         """Test upgrade."""
-        assert self.api.upgrade
-        self.api.upgrade.update()
-        assert self.api.upgrade.update_available
-        assert self.api.upgrade.available_version == "DSM 6.2.3-25426 Update 2"
-        assert self.api.upgrade.reboot_needed == "now"
-        assert self.api.upgrade.service_restarts == "some"
+        assert dsm.upgrade
+        dsm.upgrade.update()
+        assert dsm.upgrade.update_available
+        assert dsm.upgrade.available_version == "DSM 6.2.3-25426 Update 2"
+        assert dsm.upgrade.reboot_needed == "now"
+        assert dsm.upgrade.service_restarts == "some"
 
-    def test_utilisation(self):
+    def test_utilisation(self, dsm):
         """Test utilisation."""
-        assert self.api.utilisation
-        self.api.utilisation.update()
+        assert dsm.utilisation
+        dsm.utilisation.update()
 
-    def test_utilisation_error(self):
+    def test_utilisation_error(self, dsm):
         """Test utilisation error."""
-        self.api.error = True
+        dsm.error = True
         with pytest.raises(SynologyDSMAPIErrorException) as error:
-            self.api.utilisation.update()
+            dsm.utilisation.update()
         error_value = error.value.args[0]
         assert error_value["api"] == "SYNO.Core.System.Utilization"
         assert error_value["code"] == 1055
@@ -600,317 +582,304 @@ class TestSynologyDSM(TestCase):
             "err_session": "",
         }
 
-    def test_utilisation_cpu(self):
+    def test_utilisation_cpu(self, dsm):
         """Test utilisation CPU."""
-        self.api.utilisation.update()
-        assert self.api.utilisation.cpu
-        assert self.api.utilisation.cpu_other_load
-        assert self.api.utilisation.cpu_user_load
-        assert self.api.utilisation.cpu_system_load
-        assert self.api.utilisation.cpu_total_load
-        assert self.api.utilisation.cpu_1min_load
-        assert self.api.utilisation.cpu_5min_load
-        assert self.api.utilisation.cpu_15min_load
+        dsm.utilisation.update()
+        assert dsm.utilisation.cpu
+        assert dsm.utilisation.cpu_other_load
+        assert dsm.utilisation.cpu_user_load
+        assert dsm.utilisation.cpu_system_load
+        assert dsm.utilisation.cpu_total_load
+        assert dsm.utilisation.cpu_1min_load
+        assert dsm.utilisation.cpu_5min_load
+        assert dsm.utilisation.cpu_15min_load
 
-    def test_utilisation_memory(self):
+    def test_utilisation_memory(self, dsm):
         """Test utilisation memory."""
-        self.api.utilisation.update()
-        assert self.api.utilisation.memory
-        assert self.api.utilisation.memory_real_usage
-        assert self.api.utilisation.memory_size()
-        assert self.api.utilisation.memory_size(True)
-        assert self.api.utilisation.memory_available_swap()
-        assert self.api.utilisation.memory_available_swap(True)
-        assert self.api.utilisation.memory_cached()
-        assert self.api.utilisation.memory_cached(True)
-        assert self.api.utilisation.memory_available_real()
-        assert self.api.utilisation.memory_available_real(True)
-        assert self.api.utilisation.memory_total_real()
-        assert self.api.utilisation.memory_total_real(True)
-        assert self.api.utilisation.memory_total_swap()
-        assert self.api.utilisation.memory_total_swap(True)
+        dsm.utilisation.update()
+        assert dsm.utilisation.memory
+        assert dsm.utilisation.memory_real_usage
+        assert dsm.utilisation.memory_size()
+        assert dsm.utilisation.memory_size(True)
+        assert dsm.utilisation.memory_available_swap()
+        assert dsm.utilisation.memory_available_swap(True)
+        assert dsm.utilisation.memory_cached()
+        assert dsm.utilisation.memory_cached(True)
+        assert dsm.utilisation.memory_available_real()
+        assert dsm.utilisation.memory_available_real(True)
+        assert dsm.utilisation.memory_total_real()
+        assert dsm.utilisation.memory_total_real(True)
+        assert dsm.utilisation.memory_total_swap()
+        assert dsm.utilisation.memory_total_swap(True)
 
-    def test_utilisation_network(self):
+    def test_utilisation_network(self, dsm):
         """Test utilisation network."""
-        self.api.utilisation.update()
-        assert self.api.utilisation.network
-        assert self.api.utilisation.network_up()
-        assert self.api.utilisation.network_up(True)
-        assert self.api.utilisation.network_down()
-        assert self.api.utilisation.network_down(True)
+        dsm.utilisation.update()
+        assert dsm.utilisation.network
+        assert dsm.utilisation.network_up()
+        assert dsm.utilisation.network_up(True)
+        assert dsm.utilisation.network_down()
+        assert dsm.utilisation.network_down(True)
 
-    def test_storage(self):
+    def test_storage(self, dsm):
         """Test storage roots."""
-        assert self.api.storage
-        self.api.storage.update()
-        assert self.api.storage.disks
-        assert self.api.storage.env
-        assert self.api.storage.storage_pools
-        assert self.api.storage.volumes
+        assert dsm.storage
+        dsm.storage.update()
+        assert dsm.storage.disks
+        assert dsm.storage.env
+        assert dsm.storage.storage_pools
+        assert dsm.storage.volumes
 
-    def test_storage_raid_volumes(self):
+    def test_storage_raid_volumes(self, dsm):
         """Test RAID storage volumes."""
-        self.api.storage.update()
+        dsm.storage.update()
         # Basics
-        assert self.api.storage.volumes_ids
-        for volume_id in self.api.storage.volumes_ids:
+        assert dsm.storage.volumes_ids
+        for volume_id in dsm.storage.volumes_ids:
             if volume_id == "test_volume":
                 continue
-            assert self.api.storage.volume_status(volume_id)
-            assert self.api.storage.volume_device_type(volume_id)
-            assert self.api.storage.volume_size_total(volume_id)
-            assert self.api.storage.volume_size_total(volume_id, True)
-            assert self.api.storage.volume_size_used(volume_id)
-            assert self.api.storage.volume_size_used(volume_id, True)
-            assert self.api.storage.volume_percentage_used(volume_id)
-            assert self.api.storage.volume_disk_temp_avg(volume_id)
-            assert self.api.storage.volume_disk_temp_max(volume_id)
+            assert dsm.storage.volume_status(volume_id)
+            assert dsm.storage.volume_device_type(volume_id)
+            assert dsm.storage.volume_size_total(volume_id)
+            assert dsm.storage.volume_size_total(volume_id, True)
+            assert dsm.storage.volume_size_used(volume_id)
+            assert dsm.storage.volume_size_used(volume_id, True)
+            assert dsm.storage.volume_percentage_used(volume_id)
+            assert dsm.storage.volume_disk_temp_avg(volume_id)
+            assert dsm.storage.volume_disk_temp_max(volume_id)
 
         # Existing volume
-        assert self.api.storage.volume_status("volume_1") == "normal"
-        assert self.api.storage.volume_device_type("volume_1") == "raid_5"
-        assert self.api.storage.volume_size_total("volume_1") == 7672030584832
-        assert self.api.storage.volume_size_total("volume_1", True) == "7.0Tb"
-        assert self.api.storage.volume_size_used("volume_1") == 4377452806144
-        assert self.api.storage.volume_size_used("volume_1", True) == "4.0Tb"
-        assert self.api.storage.volume_percentage_used("volume_1") == 57.1
-        assert self.api.storage.volume_disk_temp_avg("volume_1") == 24.0
-        assert self.api.storage.volume_disk_temp_max("volume_1") == 24
+        assert dsm.storage.volume_status("volume_1") == "normal"
+        assert dsm.storage.volume_device_type("volume_1") == "raid_5"
+        assert dsm.storage.volume_size_total("volume_1") == 7672030584832
+        assert dsm.storage.volume_size_total("volume_1", True) == "7.0Tb"
+        assert dsm.storage.volume_size_used("volume_1") == 4377452806144
+        assert dsm.storage.volume_size_used("volume_1", True) == "4.0Tb"
+        assert dsm.storage.volume_percentage_used("volume_1") == 57.1
+        assert dsm.storage.volume_disk_temp_avg("volume_1") == 24.0
+        assert dsm.storage.volume_disk_temp_max("volume_1") == 24
 
         # Non existing volume
-        assert not self.api.storage.volume_status("not_a_volume")
-        assert not self.api.storage.volume_device_type("not_a_volume")
-        assert not self.api.storage.volume_size_total("not_a_volume")
-        assert not self.api.storage.volume_size_total("not_a_volume", True)
-        assert not self.api.storage.volume_size_used("not_a_volume")
-        assert not self.api.storage.volume_size_used("not_a_volume", True)
-        assert not self.api.storage.volume_percentage_used("not_a_volume")
-        assert not self.api.storage.volume_disk_temp_avg("not_a_volume")
-        assert not self.api.storage.volume_disk_temp_max("not_a_volume")
+        assert not dsm.storage.volume_status("not_a_volume")
+        assert not dsm.storage.volume_device_type("not_a_volume")
+        assert not dsm.storage.volume_size_total("not_a_volume")
+        assert not dsm.storage.volume_size_total("not_a_volume", True)
+        assert not dsm.storage.volume_size_used("not_a_volume")
+        assert not dsm.storage.volume_size_used("not_a_volume", True)
+        assert not dsm.storage.volume_percentage_used("not_a_volume")
+        assert not dsm.storage.volume_disk_temp_avg("not_a_volume")
+        assert not dsm.storage.volume_disk_temp_max("not_a_volume")
 
         # Test volume
-        assert self.api.storage.volume_status("test_volume") is None
-        assert self.api.storage.volume_device_type("test_volume") is None
-        assert self.api.storage.volume_size_total("test_volume") is None
-        assert self.api.storage.volume_size_total("test_volume", True) is None
-        assert self.api.storage.volume_size_used("test_volume") is None
-        assert self.api.storage.volume_size_used("test_volume", True) is None
-        assert self.api.storage.volume_percentage_used("test_volume") is None
-        assert self.api.storage.volume_disk_temp_avg("test_volume") is None
-        assert self.api.storage.volume_disk_temp_max("test_volume") is None
+        assert dsm.storage.volume_status("test_volume") is None
+        assert dsm.storage.volume_device_type("test_volume") is None
+        assert dsm.storage.volume_size_total("test_volume") is None
+        assert dsm.storage.volume_size_total("test_volume", True) is None
+        assert dsm.storage.volume_size_used("test_volume") is None
+        assert dsm.storage.volume_size_used("test_volume", True) is None
+        assert dsm.storage.volume_percentage_used("test_volume") is None
+        assert dsm.storage.volume_disk_temp_avg("test_volume") is None
+        assert dsm.storage.volume_disk_temp_max("test_volume") is None
 
-    def test_storage_shr_volumes(self):
+    def test_storage_shr_volumes(self, dsm):
         """Test SHR storage volumes."""
-        self.api.disks_redundancy = "SHR1"
-        self.api.storage.update()
+        dsm.disks_redundancy = "SHR1"
+        dsm.storage.update()
 
         # Basics
-        assert self.api.storage.volumes_ids
-        for volume_id in self.api.storage.volumes_ids:
+        assert dsm.storage.volumes_ids
+        for volume_id in dsm.storage.volumes_ids:
             if volume_id == "test_volume":
                 continue
-            assert self.api.storage.volume_status(volume_id)
-            assert self.api.storage.volume_device_type(volume_id)
-            assert self.api.storage.volume_size_total(volume_id)
-            assert self.api.storage.volume_size_total(volume_id, True)
-            assert self.api.storage.volume_size_used(volume_id)
-            assert self.api.storage.volume_size_used(volume_id, True)
-            assert self.api.storage.volume_percentage_used(volume_id)
-            assert self.api.storage.volume_disk_temp_avg(volume_id)
-            assert self.api.storage.volume_disk_temp_max(volume_id)
+            assert dsm.storage.volume_status(volume_id)
+            assert dsm.storage.volume_device_type(volume_id)
+            assert dsm.storage.volume_size_total(volume_id)
+            assert dsm.storage.volume_size_total(volume_id, True)
+            assert dsm.storage.volume_size_used(volume_id)
+            assert dsm.storage.volume_size_used(volume_id, True)
+            assert dsm.storage.volume_percentage_used(volume_id)
+            assert dsm.storage.volume_disk_temp_avg(volume_id)
+            assert dsm.storage.volume_disk_temp_max(volume_id)
 
         # Existing volume
-        assert self.api.storage.volume_status("volume_1") == "normal"
-        assert (
-            self.api.storage.volume_device_type("volume_1")
-            == "shr_without_disk_protect"
-        )
-        assert self.api.storage.volume_size_total("volume_1") == 2948623499264
-        assert self.api.storage.volume_size_total("volume_1", True) == "2.7Tb"
-        assert self.api.storage.volume_size_used("volume_1") == 2710796488704
-        assert self.api.storage.volume_size_used("volume_1", True) == "2.5Tb"
-        assert self.api.storage.volume_percentage_used("volume_1") == 91.9
-        assert self.api.storage.volume_disk_temp_avg("volume_1") == 29.0
-        assert self.api.storage.volume_disk_temp_max("volume_1") == 29
+        assert dsm.storage.volume_status("volume_1") == "normal"
+        assert dsm.storage.volume_device_type("volume_1") == "shr_without_disk_protect"
+        assert dsm.storage.volume_size_total("volume_1") == 2948623499264
+        assert dsm.storage.volume_size_total("volume_1", True) == "2.7Tb"
+        assert dsm.storage.volume_size_used("volume_1") == 2710796488704
+        assert dsm.storage.volume_size_used("volume_1", True) == "2.5Tb"
+        assert dsm.storage.volume_percentage_used("volume_1") == 91.9
+        assert dsm.storage.volume_disk_temp_avg("volume_1") == 29.0
+        assert dsm.storage.volume_disk_temp_max("volume_1") == 29
 
-        assert self.api.storage.volume_status("volume_2") == "normal"
-        assert (
-            self.api.storage.volume_device_type("volume_2")
-            == "shr_without_disk_protect"
-        )
-        assert self.api.storage.volume_size_total("volume_2") == 1964124495872
-        assert self.api.storage.volume_size_total("volume_2", True) == "1.8Tb"
-        assert self.api.storage.volume_size_used("volume_2") == 1684179374080
-        assert self.api.storage.volume_size_used("volume_2", True) == "1.5Tb"
-        assert self.api.storage.volume_percentage_used("volume_2") == 85.7
-        assert self.api.storage.volume_disk_temp_avg("volume_2") == 30.0
-        assert self.api.storage.volume_disk_temp_max("volume_2") == 30
+        assert dsm.storage.volume_status("volume_2") == "normal"
+        assert dsm.storage.volume_device_type("volume_2") == "shr_without_disk_protect"
+        assert dsm.storage.volume_size_total("volume_2") == 1964124495872
+        assert dsm.storage.volume_size_total("volume_2", True) == "1.8Tb"
+        assert dsm.storage.volume_size_used("volume_2") == 1684179374080
+        assert dsm.storage.volume_size_used("volume_2", True) == "1.5Tb"
+        assert dsm.storage.volume_percentage_used("volume_2") == 85.7
+        assert dsm.storage.volume_disk_temp_avg("volume_2") == 30.0
+        assert dsm.storage.volume_disk_temp_max("volume_2") == 30
 
         # Non existing volume
-        assert not self.api.storage.volume_status("not_a_volume")
-        assert not self.api.storage.volume_device_type("not_a_volume")
-        assert not self.api.storage.volume_size_total("not_a_volume")
-        assert not self.api.storage.volume_size_total("not_a_volume", True)
-        assert not self.api.storage.volume_size_used("not_a_volume")
-        assert not self.api.storage.volume_size_used("not_a_volume", True)
-        assert not self.api.storage.volume_percentage_used("not_a_volume")
-        assert not self.api.storage.volume_disk_temp_avg("not_a_volume")
-        assert not self.api.storage.volume_disk_temp_max("not_a_volume")
+        assert not dsm.storage.volume_status("not_a_volume")
+        assert not dsm.storage.volume_device_type("not_a_volume")
+        assert not dsm.storage.volume_size_total("not_a_volume")
+        assert not dsm.storage.volume_size_total("not_a_volume", True)
+        assert not dsm.storage.volume_size_used("not_a_volume")
+        assert not dsm.storage.volume_size_used("not_a_volume", True)
+        assert not dsm.storage.volume_percentage_used("not_a_volume")
+        assert not dsm.storage.volume_disk_temp_avg("not_a_volume")
+        assert not dsm.storage.volume_disk_temp_max("not_a_volume")
 
         # Test volume
-        assert self.api.storage.volume_status("test_volume") is None
-        assert self.api.storage.volume_device_type("test_volume") is None
-        assert self.api.storage.volume_size_total("test_volume") is None
-        assert self.api.storage.volume_size_total("test_volume", True) is None
-        assert self.api.storage.volume_size_used("test_volume") is None
-        assert self.api.storage.volume_size_used("test_volume", True) is None
-        assert self.api.storage.volume_percentage_used("test_volume") is None
-        assert self.api.storage.volume_disk_temp_avg("test_volume") is None
-        assert self.api.storage.volume_disk_temp_max("test_volume") is None
+        assert dsm.storage.volume_status("test_volume") is None
+        assert dsm.storage.volume_device_type("test_volume") is None
+        assert dsm.storage.volume_size_total("test_volume") is None
+        assert dsm.storage.volume_size_total("test_volume", True) is None
+        assert dsm.storage.volume_size_used("test_volume") is None
+        assert dsm.storage.volume_size_used("test_volume", True) is None
+        assert dsm.storage.volume_percentage_used("test_volume") is None
+        assert dsm.storage.volume_disk_temp_avg("test_volume") is None
+        assert dsm.storage.volume_disk_temp_max("test_volume") is None
 
-    def test_storage_shr2_volumes(self):
+    def test_storage_shr2_volumes(self, dsm):
         """Test SHR2 storage volumes."""
-        self.api.disks_redundancy = "SHR2"
-        self.api.storage.update()
+        dsm.disks_redundancy = "SHR2"
+        dsm.storage.update()
 
         # Basics
-        assert self.api.storage.volumes_ids
-        for volume_id in self.api.storage.volumes_ids:
-            assert self.api.storage.volume_status(volume_id)
-            assert self.api.storage.volume_device_type(volume_id)
-            assert self.api.storage.volume_size_total(volume_id)
-            assert self.api.storage.volume_size_total(volume_id, True)
-            assert self.api.storage.volume_size_used(volume_id)
-            assert self.api.storage.volume_size_used(volume_id, True)
-            assert self.api.storage.volume_percentage_used(volume_id)
-            assert self.api.storage.volume_disk_temp_avg(volume_id)
-            assert self.api.storage.volume_disk_temp_max(volume_id)
+        assert dsm.storage.volumes_ids
+        for volume_id in dsm.storage.volumes_ids:
+            assert dsm.storage.volume_status(volume_id)
+            assert dsm.storage.volume_device_type(volume_id)
+            assert dsm.storage.volume_size_total(volume_id)
+            assert dsm.storage.volume_size_total(volume_id, True)
+            assert dsm.storage.volume_size_used(volume_id)
+            assert dsm.storage.volume_size_used(volume_id, True)
+            assert dsm.storage.volume_percentage_used(volume_id)
+            assert dsm.storage.volume_disk_temp_avg(volume_id)
+            assert dsm.storage.volume_disk_temp_max(volume_id)
 
         # Existing volume
-        assert self.api.storage.volume_status("volume_1") == "normal"
-        assert (
-            self.api.storage.volume_device_type("volume_1") == "shr_with_2_disk_protect"
-        )
-        assert self.api.storage.volume_size_total("volume_1") == 38378964738048
-        assert self.api.storage.volume_size_total("volume_1", True) == "34.9Tb"
-        assert self.api.storage.volume_size_used("volume_1") == 26724878606336
-        assert self.api.storage.volume_size_used("volume_1", True) == "24.3Tb"
-        assert self.api.storage.volume_percentage_used("volume_1") == 69.6
-        assert self.api.storage.volume_disk_temp_avg("volume_1") == 37.0
-        assert self.api.storage.volume_disk_temp_max("volume_1") == 41
+        assert dsm.storage.volume_status("volume_1") == "normal"
+        assert dsm.storage.volume_device_type("volume_1") == "shr_with_2_disk_protect"
+        assert dsm.storage.volume_size_total("volume_1") == 38378964738048
+        assert dsm.storage.volume_size_total("volume_1", True) == "34.9Tb"
+        assert dsm.storage.volume_size_used("volume_1") == 26724878606336
+        assert dsm.storage.volume_size_used("volume_1", True) == "24.3Tb"
+        assert dsm.storage.volume_percentage_used("volume_1") == 69.6
+        assert dsm.storage.volume_disk_temp_avg("volume_1") == 37.0
+        assert dsm.storage.volume_disk_temp_max("volume_1") == 41
 
-    def test_storage_shr2_expansion_volumes(self):
+    def test_storage_shr2_expansion_volumes(self, dsm):
         """Test SHR2 storage with expansion unit volumes."""
-        self.api.disks_redundancy = "SHR2_EXPANSION"
-        self.api.storage.update()
+        dsm.disks_redundancy = "SHR2_EXPANSION"
+        dsm.storage.update()
 
         # Basics
-        assert self.api.storage.volumes_ids
-        for volume_id in self.api.storage.volumes_ids:
-            assert self.api.storage.volume_status(volume_id)
-            assert self.api.storage.volume_device_type(volume_id)
-            assert self.api.storage.volume_size_total(volume_id)
-            assert self.api.storage.volume_size_total(volume_id, True)
-            assert self.api.storage.volume_size_used(volume_id)
-            assert self.api.storage.volume_size_used(volume_id, True)
-            assert self.api.storage.volume_percentage_used(volume_id)
-            assert self.api.storage.volume_disk_temp_avg(volume_id)
-            assert self.api.storage.volume_disk_temp_max(volume_id)
+        assert dsm.storage.volumes_ids
+        for volume_id in dsm.storage.volumes_ids:
+            assert dsm.storage.volume_status(volume_id)
+            assert dsm.storage.volume_device_type(volume_id)
+            assert dsm.storage.volume_size_total(volume_id)
+            assert dsm.storage.volume_size_total(volume_id, True)
+            assert dsm.storage.volume_size_used(volume_id)
+            assert dsm.storage.volume_size_used(volume_id, True)
+            assert dsm.storage.volume_percentage_used(volume_id)
+            assert dsm.storage.volume_disk_temp_avg(volume_id)
+            assert dsm.storage.volume_disk_temp_max(volume_id)
 
         # Existing volume
-        assert self.api.storage.volume_status("volume_1") == "normal"
-        assert (
-            self.api.storage.volume_device_type("volume_1") == "shr_with_2_disk_protect"
-        )
-        assert self.api.storage.volume_size_total("volume_1") == 31714659872768
-        assert self.api.storage.volume_size_total("volume_1", True) == "28.8Tb"
-        assert self.api.storage.volume_size_used("volume_1") == 25419707531264
-        assert self.api.storage.volume_size_used("volume_1", True) == "23.1Tb"
-        assert self.api.storage.volume_percentage_used("volume_1") == 80.2
-        assert self.api.storage.volume_disk_temp_avg("volume_1") == 33.0
-        assert self.api.storage.volume_disk_temp_max("volume_1") == 35
+        assert dsm.storage.volume_status("volume_1") == "normal"
+        assert dsm.storage.volume_device_type("volume_1") == "shr_with_2_disk_protect"
+        assert dsm.storage.volume_size_total("volume_1") == 31714659872768
+        assert dsm.storage.volume_size_total("volume_1", True) == "28.8Tb"
+        assert dsm.storage.volume_size_used("volume_1") == 25419707531264
+        assert dsm.storage.volume_size_used("volume_1", True) == "23.1Tb"
+        assert dsm.storage.volume_percentage_used("volume_1") == 80.2
+        assert dsm.storage.volume_disk_temp_avg("volume_1") == 33.0
+        assert dsm.storage.volume_disk_temp_max("volume_1") == 35
 
-    def test_storage_disks(self):
+    def test_storage_disks(self, dsm):
         """Test storage disks."""
-        self.api.storage.update()
+        dsm.storage.update()
         # Basics
-        assert self.api.storage.disks_ids
-        for disk_id in self.api.storage.disks_ids:
+        assert dsm.storage.disks_ids
+        for disk_id in dsm.storage.disks_ids:
             if disk_id == "test_disk":
                 continue
-            assert "Drive" in self.api.storage.disk_name(disk_id)
-            assert "/dev/" in self.api.storage.disk_device(disk_id)
-            assert self.api.storage.disk_smart_status(disk_id) == "normal"
-            assert self.api.storage.disk_status(disk_id) == "normal"
-            assert not self.api.storage.disk_exceed_bad_sector_thr(disk_id)
-            assert not self.api.storage.disk_below_remain_life_thr(disk_id)
-            assert self.api.storage.disk_temp(disk_id)
+            assert "Drive" in dsm.storage.disk_name(disk_id)
+            assert "/dev/" in dsm.storage.disk_device(disk_id)
+            assert dsm.storage.disk_smart_status(disk_id) == "normal"
+            assert dsm.storage.disk_status(disk_id) == "normal"
+            assert not dsm.storage.disk_exceed_bad_sector_thr(disk_id)
+            assert not dsm.storage.disk_below_remain_life_thr(disk_id)
+            assert dsm.storage.disk_temp(disk_id)
 
         # Non existing disk
-        assert not self.api.storage.disk_name("not_a_disk")
-        assert not self.api.storage.disk_device("not_a_disk")
-        assert not self.api.storage.disk_smart_status("not_a_disk")
-        assert not self.api.storage.disk_status("not_a_disk")
-        assert not self.api.storage.disk_exceed_bad_sector_thr("not_a_disk")
-        assert not self.api.storage.disk_below_remain_life_thr("not_a_disk")
-        assert not self.api.storage.disk_temp("not_a_disk")
+        assert not dsm.storage.disk_name("not_a_disk")
+        assert not dsm.storage.disk_device("not_a_disk")
+        assert not dsm.storage.disk_smart_status("not_a_disk")
+        assert not dsm.storage.disk_status("not_a_disk")
+        assert not dsm.storage.disk_exceed_bad_sector_thr("not_a_disk")
+        assert not dsm.storage.disk_below_remain_life_thr("not_a_disk")
+        assert not dsm.storage.disk_temp("not_a_disk")
 
         # Test disk
-        assert self.api.storage.disk_name("test_disk") is None
-        assert self.api.storage.disk_device("test_disk") is None
-        assert self.api.storage.disk_smart_status("test_disk") is None
-        assert self.api.storage.disk_status("test_disk") is None
-        assert self.api.storage.disk_exceed_bad_sector_thr("test_disk") is None
-        assert self.api.storage.disk_below_remain_life_thr("test_disk") is None
-        assert self.api.storage.disk_temp("test_disk") is None
+        assert dsm.storage.disk_name("test_disk") is None
+        assert dsm.storage.disk_device("test_disk") is None
+        assert dsm.storage.disk_smart_status("test_disk") is None
+        assert dsm.storage.disk_status("test_disk") is None
+        assert dsm.storage.disk_exceed_bad_sector_thr("test_disk") is None
+        assert dsm.storage.disk_below_remain_life_thr("test_disk") is None
+        assert dsm.storage.disk_temp("test_disk") is None
 
-    def test_download_station(self):
+    def test_download_station(self, dsm):
         """Test DownloadStation."""
-        assert self.api.download_station
-        assert not self.api.download_station.get_all_tasks()
+        assert dsm.download_station
+        assert not dsm.download_station.get_all_tasks()
 
-        assert self.api.download_station.get_info()["data"]["version"]
-        assert self.api.download_station.get_config()["data"]["default_destination"]
-        assert self.api.download_station.get_stat()["data"]["speed_download"]
-        self.api.download_station.update()
-        assert self.api.download_station.get_all_tasks()
-        assert len(self.api.download_station.get_all_tasks()) == 8
+        assert dsm.download_station.get_info()["data"]["version"]
+        assert dsm.download_station.get_config()["data"]["default_destination"]
+        assert dsm.download_station.get_stat()["data"]["speed_download"]
+        dsm.download_station.update()
+        assert dsm.download_station.get_all_tasks()
+        assert len(dsm.download_station.get_all_tasks()) == 8
 
         # BT DL
-        assert self.api.download_station.get_task("dbid_86").status == "downloading"
-        assert not self.api.download_station.get_task("dbid_86").status_extra
-        assert self.api.download_station.get_task("dbid_86").type == "bt"
-        assert self.api.download_station.get_task("dbid_86").additional.get("file")
-        assert (
-            len(self.api.download_station.get_task("dbid_86").additional.get("file"))
-            == 9
-        )
+        assert dsm.download_station.get_task("dbid_86").status == "downloading"
+        assert not dsm.download_station.get_task("dbid_86").status_extra
+        assert dsm.download_station.get_task("dbid_86").type == "bt"
+        assert dsm.download_station.get_task("dbid_86").additional.get("file")
+        assert len(dsm.download_station.get_task("dbid_86").additional.get("file")) == 9
 
         # HTTPS error
-        assert self.api.download_station.get_task("dbid_549").status == "error"
+        assert dsm.download_station.get_task("dbid_549").status == "error"
         assert (
-            self.api.download_station.get_task("dbid_549").status_extra["error_detail"]
+            dsm.download_station.get_task("dbid_549").status_extra["error_detail"]
             == "broken_link"
         )
-        assert self.api.download_station.get_task("dbid_549").type == "https"
+        assert dsm.download_station.get_task("dbid_549").type == "https"
 
-    def test_surveillance_station(self):
+    def test_surveillance_station(self, dsm):
         """Test SurveillanceStation."""
-        self.api.with_surveillance = True
-        assert self.api.surveillance_station
-        assert not self.api.surveillance_station.get_all_cameras()
+        dsm.with_surveillance = True
+        assert dsm.surveillance_station
+        assert not dsm.surveillance_station.get_all_cameras()
 
-        self.api.surveillance_station.update()
-        assert self.api.surveillance_station.get_all_cameras()
-        assert self.api.surveillance_station.get_camera(1)
-        assert self.api.surveillance_station.get_camera_live_view_path(1)
-        assert self.api.surveillance_station.get_camera_live_view_path(1, "rtsp")
+        dsm.surveillance_station.update()
+        assert dsm.surveillance_station.get_all_cameras()
+        assert dsm.surveillance_station.get_camera(1)
+        assert dsm.surveillance_station.get_camera_live_view_path(1)
+        assert dsm.surveillance_station.get_camera_live_view_path(1, "rtsp")
 
         # Motion detection
-        assert self.api.surveillance_station.enable_motion_detection(1).get("success")
-        assert self.api.surveillance_station.disable_motion_detection(1).get("success")
+        assert dsm.surveillance_station.enable_motion_detection(1).get("success")
+        assert dsm.surveillance_station.disable_motion_detection(1).get("success")
 
         # Home mode
-        assert self.api.surveillance_station.get_home_mode_status()
-        assert self.api.surveillance_station.set_home_mode(False)
-        assert self.api.surveillance_station.set_home_mode(True)
+        assert dsm.surveillance_station.get_home_mode_status()
+        assert dsm.surveillance_station.set_home_mode(False)
+        assert dsm.surveillance_station.set_home_mode(True)

--- a/tests/test_synology_dsm_5.py
+++ b/tests/test_synology_dsm_5.py
@@ -1,5 +1,5 @@
 """Synology DSM tests."""
-from unittest import TestCase
+import pytest
 
 from . import SynologyDSMMock
 from . import VALID_HOST
@@ -22,33 +22,19 @@ from synology_dsm.exceptions import SynologyDSMLoginInvalidException
 from synology_dsm.exceptions import SynologyDSMRequestException
 
 
-class TestSynologyDSM(TestCase):
+class TestSynologyDSM:
     """SynologyDSM test cases."""
 
-    api = None
-
-    def setUp(self):
-        """Context initialisation called for all tests."""
-        self.api = SynologyDSMMock(
-            VALID_HOST,
-            VALID_PORT,
-            VALID_USER,
-            VALID_PASSWORD,
-            VALID_HTTPS,
-            VALID_VERIFY_SSL,
-        )
-        self.api.dsm_version = 5
-
-    def test_init(self):
+    def test_init(self, dsm_5):
         """Test init."""
-        assert self.api.username
-        assert self.api._base_url
-        assert not self.api.apis.get(API_AUTH)
-        assert not self.api._session_id
+        assert dsm_5.username
+        assert dsm_5._base_url
+        assert not dsm_5.apis.get(API_AUTH)
+        assert not dsm_5._session_id
 
     def test_connection_failed(self):
         """Test failed connection."""
-        api = SynologyDSMMock(
+        dsm_5 = SynologyDSMMock(
             "no_internet",
             VALID_PORT,
             VALID_USER,
@@ -56,13 +42,13 @@ class TestSynologyDSM(TestCase):
             VALID_HTTPS,
             VALID_VERIFY_SSL,
         )
-        api.dsm_version = 5
-        with self.assertRaises(SynologyDSMRequestException):
-            assert not api.login()
-        assert not api.apis.get(API_AUTH)
-        assert not api._session_id
+        dsm_5.dsm_version = 5
+        with pytest.raises(SynologyDSMRequestException):
+            assert not dsm_5.login()
+        assert not dsm_5.apis.get(API_AUTH)
+        assert not dsm_5._session_id
 
-        api = SynologyDSMMock(
+        dsm_5 = SynologyDSMMock(
             "host",
             VALID_PORT,
             VALID_USER,
@@ -70,22 +56,22 @@ class TestSynologyDSM(TestCase):
             VALID_HTTPS,
             VALID_VERIFY_SSL,
         )
-        api.dsm_version = 5
-        with self.assertRaises(SynologyDSMRequestException):
-            assert not api.login()
-        assert not api.apis.get(API_AUTH)
-        assert not api._session_id
+        dsm_5.dsm_version = 5
+        with pytest.raises(SynologyDSMRequestException):
+            assert not dsm_5.login()
+        assert not dsm_5.apis.get(API_AUTH)
+        assert not dsm_5._session_id
 
-        api = SynologyDSMMock(
+        dsm_5 = SynologyDSMMock(
             VALID_HOST, 0, VALID_USER, VALID_PASSWORD, VALID_HTTPS, VALID_VERIFY_SSL
         )
-        api.dsm_version = 5
-        with self.assertRaises(SynologyDSMRequestException):
-            assert not api.login()
-        assert not api.apis.get(API_AUTH)
-        assert not api._session_id
+        dsm_5.dsm_version = 5
+        with pytest.raises(SynologyDSMRequestException):
+            assert not dsm_5.login()
+        assert not dsm_5.apis.get(API_AUTH)
+        assert not dsm_5._session_id
 
-        api = SynologyDSMMock(
+        dsm_5 = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER,
@@ -93,22 +79,22 @@ class TestSynologyDSM(TestCase):
             False,
             VALID_VERIFY_SSL,
         )
-        api.dsm_version = 5
-        with self.assertRaises(SynologyDSMRequestException):
-            assert not api.login()
-        assert not api.apis.get(API_AUTH)
-        assert not api._session_id
+        dsm_5.dsm_version = 5
+        with pytest.raises(SynologyDSMRequestException):
+            assert not dsm_5.login()
+        assert not dsm_5.apis.get(API_AUTH)
+        assert not dsm_5._session_id
 
-    def test_login(self):
+    def test_login(self, dsm_5):
         """Test login."""
-        assert self.api.login()
-        assert self.api.apis.get(API_AUTH)
-        assert self.api._session_id == SESSION_ID
-        assert self.api._syno_token is None
+        assert dsm_5.login()
+        assert dsm_5.apis.get(API_AUTH)
+        assert dsm_5._session_id == SESSION_ID
+        assert dsm_5._syno_token is None
 
     def test_login_failed(self):
         """Test failed login."""
-        api = SynologyDSMMock(
+        dsm_5 = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             "user",
@@ -116,13 +102,13 @@ class TestSynologyDSM(TestCase):
             VALID_HTTPS,
             VALID_VERIFY_SSL,
         )
-        api.dsm_version = 5
-        with self.assertRaises(SynologyDSMLoginInvalidException):
-            assert not api.login()
-        assert api.apis.get(API_AUTH)
-        assert not api._session_id
+        dsm_5.dsm_version = 5
+        with pytest.raises(SynologyDSMLoginInvalidException):
+            assert not dsm_5.login()
+        assert dsm_5.apis.get(API_AUTH)
+        assert not dsm_5._session_id
 
-        api = SynologyDSMMock(
+        dsm_5 = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER,
@@ -130,15 +116,15 @@ class TestSynologyDSM(TestCase):
             VALID_HTTPS,
             VALID_VERIFY_SSL,
         )
-        api.dsm_version = 5
-        with self.assertRaises(SynologyDSMLoginInvalidException):
-            assert not api.login()
-        assert api.apis.get(API_AUTH)
-        assert not api._session_id
+        dsm_5.dsm_version = 5
+        with pytest.raises(SynologyDSMLoginInvalidException):
+            assert not dsm_5.login()
+        assert dsm_5.apis.get(API_AUTH)
+        assert not dsm_5._session_id
 
     def test_login_2sa(self):
         """Test login with 2SA."""
-        api = SynologyDSMMock(
+        dsm_5 = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
@@ -146,19 +132,19 @@ class TestSynologyDSM(TestCase):
             VALID_HTTPS,
             VALID_VERIFY_SSL,
         )
-        api.dsm_version = 5
-        with self.assertRaises(SynologyDSMLogin2SARequiredException):
-            api.login()
-        api.login(VALID_OTP)
+        dsm_5.dsm_version = 5
+        with pytest.raises(SynologyDSMLogin2SARequiredException):
+            dsm_5.login()
+        dsm_5.login(VALID_OTP)
 
-        assert api._session_id == SESSION_ID
-        assert api._syno_token is None
-        assert api._device_token == DEVICE_TOKEN
-        assert api.device_token == DEVICE_TOKEN
+        assert dsm_5._session_id == SESSION_ID
+        assert dsm_5._syno_token is None
+        assert dsm_5._device_token == DEVICE_TOKEN
+        assert dsm_5.device_token == DEVICE_TOKEN
 
     def test_login_2sa_new_session(self):
         """Test login with 2SA and a new session with granted device."""
-        api = SynologyDSMMock(
+        dsm_5 = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
@@ -167,17 +153,17 @@ class TestSynologyDSM(TestCase):
             VALID_VERIFY_SSL,
             device_token=DEVICE_TOKEN,
         )
-        api.dsm_version = 5
-        assert api.login()
+        dsm_5.dsm_version = 5
+        assert dsm_5.login()
 
-        assert api._session_id == SESSION_ID
-        assert api._syno_token is None
-        assert api._device_token == DEVICE_TOKEN
-        assert api.device_token == DEVICE_TOKEN
+        assert dsm_5._session_id == SESSION_ID
+        assert dsm_5._syno_token is None
+        assert dsm_5._device_token == DEVICE_TOKEN
+        assert dsm_5.device_token == DEVICE_TOKEN
 
     def test_login_2sa_failed(self):
         """Test failed login with 2SA."""
-        api = SynologyDSMMock(
+        dsm_5 = SynologyDSMMock(
             VALID_HOST,
             VALID_PORT,
             VALID_USER_2SA,
@@ -185,38 +171,38 @@ class TestSynologyDSM(TestCase):
             VALID_HTTPS,
             VALID_VERIFY_SSL,
         )
-        api.dsm_version = 5
-        with self.assertRaises(SynologyDSMLogin2SARequiredException):
-            api.login()
-        with self.assertRaises(SynologyDSMLogin2SAFailedException):
-            api.login(888888)
+        dsm_5.dsm_version = 5
+        with pytest.raises(SynologyDSMLogin2SARequiredException):
+            dsm_5.login()
+        with pytest.raises(SynologyDSMLogin2SAFailedException):
+            dsm_5.login(888888)
 
-        assert api._session_id is None
-        assert api._syno_token is None
-        assert api._device_token is None
+        assert dsm_5._session_id is None
+        assert dsm_5._syno_token is None
+        assert dsm_5._device_token is None
 
-    def test_request_get(self):
+    def test_request_get(self, dsm_5):
         """Test get request."""
-        assert self.api.get(API_INFO, "query")
-        assert self.api.get(API_AUTH, "login")
-        assert self.api.get("SYNO.DownloadStation2.Task", "list")
-        assert self.api.get(API_AUTH, "logout")
+        assert dsm_5.get(API_INFO, "query")
+        assert dsm_5.get(API_AUTH, "login")
+        assert dsm_5.get("SYNO.DownloadStation2.Task", "list")
+        assert dsm_5.get(API_AUTH, "logout")
 
-    def test_request_get_failed(self):
+    def test_request_get_failed(self, dsm_5):
         """Test failed get request."""
-        with self.assertRaises(SynologyDSMAPINotExistsException):
-            assert self.api.get("SYNO.Virtualization.API.Task.Info", "list")
+        with pytest.raises(SynologyDSMAPINotExistsException):
+            assert dsm_5.get("SYNO.Virtualization.dsm_5.Task.Info", "list")
 
-    def test_request_post(self):
+    def test_request_post(self, dsm_5):
         """Test post request."""
-        assert self.api.post(
+        assert dsm_5.post(
             "SYNO.FileStation.Upload",
             "upload",
             params={"dest_folder_path": "/upload/test", "create_parents": True},
             files={"file": "open('file.txt','rb')"},
         )
 
-        assert self.api.post(
+        assert dsm_5.post(
             "SYNO.DownloadStation2.Task",
             "create",
             params={
@@ -226,18 +212,18 @@ class TestSynologyDSM(TestCase):
             },
         )
 
-    def test_request_post_failed(self):
+    def test_request_post_failed(self, dsm_5):
         """Test failed post request."""
-        with self.assertRaises(SynologyDSMAPIErrorException):
-            assert self.api.post(
+        with pytest.raises(SynologyDSMAPIErrorException):
+            assert dsm_5.post(
                 "SYNO.FileStation.Upload",
                 "upload",
                 params={"dest_folder_path": "/upload/test", "create_parents": True},
                 files={"file": "open('file_already_exists.txt','rb')"},
             )
 
-        with self.assertRaises(SynologyDSMAPIErrorException):
-            assert self.api.post(
+        with pytest.raises(SynologyDSMAPIErrorException):
+            assert dsm_5.post(
                 "SYNO.DownloadStation2.Task",
                 "create",
                 params={
@@ -247,177 +233,177 @@ class TestSynologyDSM(TestCase):
                 },
             )
 
-    def test_information(self):
+    def test_information(self, dsm_5):
         """Test information."""
-        assert self.api.information
-        self.api.information.update()
-        assert self.api.information.model == "DS3615xs"
-        assert self.api.information.ram == 6144
-        assert self.api.information.serial == "B3J4N01003"
-        assert self.api.information.temperature == 40
-        assert not self.api.information.temperature_warn
-        assert self.api.information.uptime == 3897
-        assert self.api.information.version == "5967"
-        assert self.api.information.version_string == "DSM 5.2-5967 Update 9"
+        assert dsm_5.information
+        dsm_5.information.update()
+        assert dsm_5.information.model == "DS3615xs"
+        assert dsm_5.information.ram == 6144
+        assert dsm_5.information.serial == "B3J4N01003"
+        assert dsm_5.information.temperature == 40
+        assert not dsm_5.information.temperature_warn
+        assert dsm_5.information.uptime == 3897
+        assert dsm_5.information.version == "5967"
+        assert dsm_5.information.version_string == "DSM 5.2-5967 Update 9"
 
-    def test_network(self):
+    def test_network(self, dsm_5):
         """Test network."""
-        assert self.api.network
-        self.api.network.update()
-        assert self.api.network.dns
-        assert self.api.network.gateway
-        assert self.api.network.hostname
-        assert self.api.network.interfaces
-        assert self.api.network.interface("eth0")
-        assert self.api.network.interface("eth1") is None
-        assert self.api.network.macs
-        assert self.api.network.workgroup
+        assert dsm_5.network
+        dsm_5.network.update()
+        assert dsm_5.network.dns
+        assert dsm_5.network.gateway
+        assert dsm_5.network.hostname
+        assert dsm_5.network.interfaces
+        assert dsm_5.network.interface("eth0")
+        assert dsm_5.network.interface("eth1") is None
+        assert dsm_5.network.macs
+        assert dsm_5.network.workgroup
 
-    def test_utilisation(self):
+    def test_utilisation(self, dsm_5):
         """Test utilization."""
-        assert self.api.utilisation
-        self.api.utilisation.update()
+        assert dsm_5.utilisation
+        dsm_5.utilisation.update()
 
-    def test_utilisation_cpu(self):
+    def test_utilisation_cpu(self, dsm_5):
         """Test utilization CPU."""
-        self.api.utilisation.update()
-        assert self.api.utilisation.cpu
-        assert self.api.utilisation.cpu_other_load
-        assert self.api.utilisation.cpu_user_load
-        assert self.api.utilisation.cpu_system_load
-        assert self.api.utilisation.cpu_total_load
-        assert self.api.utilisation.cpu_1min_load
-        assert self.api.utilisation.cpu_5min_load
-        assert self.api.utilisation.cpu_15min_load
+        dsm_5.utilisation.update()
+        assert dsm_5.utilisation.cpu
+        assert dsm_5.utilisation.cpu_other_load
+        assert dsm_5.utilisation.cpu_user_load
+        assert dsm_5.utilisation.cpu_system_load
+        assert dsm_5.utilisation.cpu_total_load
+        assert dsm_5.utilisation.cpu_1min_load
+        assert dsm_5.utilisation.cpu_5min_load
+        assert dsm_5.utilisation.cpu_15min_load
 
-    def test_utilisation_memory(self):
+    def test_utilisation_memory(self, dsm_5):
         """Test utilization memory."""
-        self.api.utilisation.update()
-        assert self.api.utilisation.memory
-        assert self.api.utilisation.memory_real_usage
-        assert self.api.utilisation.memory_size()
-        assert self.api.utilisation.memory_size(True)
-        assert self.api.utilisation.memory_available_swap()
-        assert self.api.utilisation.memory_available_swap(True)
-        assert self.api.utilisation.memory_cached()
-        assert self.api.utilisation.memory_cached(True)
-        assert self.api.utilisation.memory_available_real()
-        assert self.api.utilisation.memory_available_real(True)
-        assert self.api.utilisation.memory_total_real()
-        assert self.api.utilisation.memory_total_real(True)
-        assert self.api.utilisation.memory_total_swap()
-        assert self.api.utilisation.memory_total_swap(True)
+        dsm_5.utilisation.update()
+        assert dsm_5.utilisation.memory
+        assert dsm_5.utilisation.memory_real_usage
+        assert dsm_5.utilisation.memory_size()
+        assert dsm_5.utilisation.memory_size(True)
+        assert dsm_5.utilisation.memory_available_swap()
+        assert dsm_5.utilisation.memory_available_swap(True)
+        assert dsm_5.utilisation.memory_cached()
+        assert dsm_5.utilisation.memory_cached(True)
+        assert dsm_5.utilisation.memory_available_real()
+        assert dsm_5.utilisation.memory_available_real(True)
+        assert dsm_5.utilisation.memory_total_real()
+        assert dsm_5.utilisation.memory_total_real(True)
+        assert dsm_5.utilisation.memory_total_swap()
+        assert dsm_5.utilisation.memory_total_swap(True)
 
-    def test_utilisation_network(self):
+    def test_utilisation_network(self, dsm_5):
         """Test utilization network."""
-        self.api.utilisation.update()
-        assert self.api.utilisation.network
-        assert self.api.utilisation.network_up()
-        assert self.api.utilisation.network_up(True)
-        assert self.api.utilisation.network_down()
-        assert self.api.utilisation.network_down(True)
+        dsm_5.utilisation.update()
+        assert dsm_5.utilisation.network
+        assert dsm_5.utilisation.network_up()
+        assert dsm_5.utilisation.network_up(True)
+        assert dsm_5.utilisation.network_down()
+        assert dsm_5.utilisation.network_down(True)
 
-    def test_storage(self):
+    def test_storage(self, dsm_5):
         """Test storage roots."""
-        assert self.api.storage
-        self.api.storage.update()
-        assert self.api.storage.disks
-        assert self.api.storage.env
-        assert self.api.storage.storage_pools == []
-        assert self.api.storage.volumes
+        assert dsm_5.storage
+        dsm_5.storage.update()
+        assert dsm_5.storage.disks
+        assert dsm_5.storage.env
+        assert dsm_5.storage.storage_pools == []
+        assert dsm_5.storage.volumes
 
-    def test_storage_volumes(self):
+    def test_storage_volumes(self, dsm_5):
         """Test storage volumes."""
-        self.api.storage.update()
+        dsm_5.storage.update()
         # Basics
-        assert self.api.storage.volumes_ids
-        for volume_id in self.api.storage.volumes_ids:
+        assert dsm_5.storage.volumes_ids
+        for volume_id in dsm_5.storage.volumes_ids:
             if volume_id == "test_volume":
                 continue
-            assert self.api.storage.volume_status(volume_id)
-            assert self.api.storage.volume_device_type(volume_id)
-            assert self.api.storage.volume_size_total(volume_id)
-            assert self.api.storage.volume_size_total(volume_id, True)
-            assert self.api.storage.volume_size_used(volume_id)
-            assert self.api.storage.volume_size_used(volume_id, True)
-            assert self.api.storage.volume_percentage_used(volume_id)
+            assert dsm_5.storage.volume_status(volume_id)
+            assert dsm_5.storage.volume_device_type(volume_id)
+            assert dsm_5.storage.volume_size_total(volume_id)
+            assert dsm_5.storage.volume_size_total(volume_id, True)
+            assert dsm_5.storage.volume_size_used(volume_id)
+            assert dsm_5.storage.volume_size_used(volume_id, True)
+            assert dsm_5.storage.volume_percentage_used(volume_id)
             assert (
-                self.api.storage.volume_disk_temp_avg(volume_id) is None
+                dsm_5.storage.volume_disk_temp_avg(volume_id) is None
             )  # because of empty storagePools
             assert (
-                self.api.storage.volume_disk_temp_max(volume_id) is None
+                dsm_5.storage.volume_disk_temp_max(volume_id) is None
             )  # because of empty storagePools
 
         # Existing volume
-        assert self.api.storage.volume_status("volume_1") == "normal"
-        assert self.api.storage.volume_device_type("volume_1") == "raid_5"
-        assert self.api.storage.volume_size_total("volume_1") == 8846249701376
-        assert self.api.storage.volume_size_total("volume_1", True) == "8.0Tb"
-        assert self.api.storage.volume_size_used("volume_1") == 5719795761152
-        assert self.api.storage.volume_size_used("volume_1", True) == "5.2Tb"
-        assert self.api.storage.volume_percentage_used("volume_1") == 64.7
+        assert dsm_5.storage.volume_status("volume_1") == "normal"
+        assert dsm_5.storage.volume_device_type("volume_1") == "raid_5"
+        assert dsm_5.storage.volume_size_total("volume_1") == 8846249701376
+        assert dsm_5.storage.volume_size_total("volume_1", True) == "8.0Tb"
+        assert dsm_5.storage.volume_size_used("volume_1") == 5719795761152
+        assert dsm_5.storage.volume_size_used("volume_1", True) == "5.2Tb"
+        assert dsm_5.storage.volume_percentage_used("volume_1") == 64.7
         assert (
-            self.api.storage.volume_disk_temp_avg("volume_1") is None
+            dsm_5.storage.volume_disk_temp_avg("volume_1") is None
         )  # because of empty storagePools
         assert (
-            self.api.storage.volume_disk_temp_max("volume_1") is None
+            dsm_5.storage.volume_disk_temp_max("volume_1") is None
         )  # because of empty storagePools
 
         # Non existing volume
-        assert not self.api.storage.volume_status("not_a_volume")
-        assert not self.api.storage.volume_device_type("not_a_volume")
-        assert not self.api.storage.volume_size_total("not_a_volume")
-        assert not self.api.storage.volume_size_total("not_a_volume", True)
-        assert not self.api.storage.volume_size_used("not_a_volume")
-        assert not self.api.storage.volume_size_used("not_a_volume", True)
-        assert not self.api.storage.volume_percentage_used("not_a_volume")
-        assert not self.api.storage.volume_disk_temp_avg("not_a_volume")
-        assert not self.api.storage.volume_disk_temp_max("not_a_volume")
+        assert not dsm_5.storage.volume_status("not_a_volume")
+        assert not dsm_5.storage.volume_device_type("not_a_volume")
+        assert not dsm_5.storage.volume_size_total("not_a_volume")
+        assert not dsm_5.storage.volume_size_total("not_a_volume", True)
+        assert not dsm_5.storage.volume_size_used("not_a_volume")
+        assert not dsm_5.storage.volume_size_used("not_a_volume", True)
+        assert not dsm_5.storage.volume_percentage_used("not_a_volume")
+        assert not dsm_5.storage.volume_disk_temp_avg("not_a_volume")
+        assert not dsm_5.storage.volume_disk_temp_max("not_a_volume")
 
         # Test volume
-        assert self.api.storage.volume_status("test_volume") is None
-        assert self.api.storage.volume_device_type("test_volume") is None
-        assert self.api.storage.volume_size_total("test_volume") is None
-        assert self.api.storage.volume_size_total("test_volume", True) is None
-        assert self.api.storage.volume_size_used("test_volume") is None
-        assert self.api.storage.volume_size_used("test_volume", True) is None
-        assert self.api.storage.volume_percentage_used("test_volume") is None
-        assert self.api.storage.volume_disk_temp_avg("test_volume") is None
-        assert self.api.storage.volume_disk_temp_max("test_volume") is None
+        assert dsm_5.storage.volume_status("test_volume") is None
+        assert dsm_5.storage.volume_device_type("test_volume") is None
+        assert dsm_5.storage.volume_size_total("test_volume") is None
+        assert dsm_5.storage.volume_size_total("test_volume", True) is None
+        assert dsm_5.storage.volume_size_used("test_volume") is None
+        assert dsm_5.storage.volume_size_used("test_volume", True) is None
+        assert dsm_5.storage.volume_percentage_used("test_volume") is None
+        assert dsm_5.storage.volume_disk_temp_avg("test_volume") is None
+        assert dsm_5.storage.volume_disk_temp_max("test_volume") is None
 
-    def test_storage_disks(self):
+    def test_storage_disks(self, dsm_5):
         """Test storage disks."""
-        self.api.storage.update()
+        dsm_5.storage.update()
         # Basics
-        assert self.api.storage.disks_ids
-        for disk_id in self.api.storage.disks_ids:
+        assert dsm_5.storage.disks_ids
+        for disk_id in dsm_5.storage.disks_ids:
             if disk_id == "test_disk":
                 continue
-            assert "Disk" in self.api.storage.disk_name(disk_id)
-            assert "/dev/" in self.api.storage.disk_device(disk_id)
+            assert "Disk" in dsm_5.storage.disk_name(disk_id)
+            assert "/dev/" in dsm_5.storage.disk_device(disk_id)
             if disk_id == "sda":
-                assert self.api.storage.disk_smart_status(disk_id) == "90%"
+                assert dsm_5.storage.disk_smart_status(disk_id) == "90%"
             else:
-                assert self.api.storage.disk_smart_status(disk_id) == "safe"
-            assert self.api.storage.disk_status(disk_id) == "normal"
-            assert not self.api.storage.disk_exceed_bad_sector_thr(disk_id)
-            assert not self.api.storage.disk_below_remain_life_thr(disk_id)
-            assert self.api.storage.disk_temp(disk_id)
+                assert dsm_5.storage.disk_smart_status(disk_id) == "safe"
+            assert dsm_5.storage.disk_status(disk_id) == "normal"
+            assert not dsm_5.storage.disk_exceed_bad_sector_thr(disk_id)
+            assert not dsm_5.storage.disk_below_remain_life_thr(disk_id)
+            assert dsm_5.storage.disk_temp(disk_id)
 
         # Non existing disk
-        assert not self.api.storage.disk_name("not_a_disk")
-        assert not self.api.storage.disk_device("not_a_disk")
-        assert not self.api.storage.disk_smart_status("not_a_disk")
-        assert not self.api.storage.disk_status("not_a_disk")
-        assert not self.api.storage.disk_exceed_bad_sector_thr("not_a_disk")
-        assert not self.api.storage.disk_below_remain_life_thr("not_a_disk")
-        assert not self.api.storage.disk_temp("not_a_disk")
+        assert not dsm_5.storage.disk_name("not_a_disk")
+        assert not dsm_5.storage.disk_device("not_a_disk")
+        assert not dsm_5.storage.disk_smart_status("not_a_disk")
+        assert not dsm_5.storage.disk_status("not_a_disk")
+        assert not dsm_5.storage.disk_exceed_bad_sector_thr("not_a_disk")
+        assert not dsm_5.storage.disk_below_remain_life_thr("not_a_disk")
+        assert not dsm_5.storage.disk_temp("not_a_disk")
 
         # Test disk
-        assert self.api.storage.disk_name("test_disk") is None
-        assert self.api.storage.disk_device("test_disk") is None
-        assert self.api.storage.disk_smart_status("test_disk") is None
-        assert self.api.storage.disk_status("test_disk") is None
-        assert self.api.storage.disk_exceed_bad_sector_thr("test_disk") is None
-        assert self.api.storage.disk_below_remain_life_thr("test_disk") is None
-        assert self.api.storage.disk_temp("test_disk") is None
+        assert dsm_5.storage.disk_name("test_disk") is None
+        assert dsm_5.storage.disk_device("test_disk") is None
+        assert dsm_5.storage.disk_smart_status("test_disk") is None
+        assert dsm_5.storage.disk_status("test_disk") is None
+        assert dsm_5.storage.disk_exceed_bad_sector_thr("test_disk") is None
+        assert dsm_5.storage.disk_below_remain_life_thr("test_disk") is None
+        assert dsm_5.storage.disk_temp("test_disk") is None


### PR DESCRIPTION
See https://docs.pytest.org/en/documentation-restructure/how-to/fixture.html

Pytest fixtures are really powerful. Currently, the existing tests were a mix between pytest and unittest. I fully migrated them to pytest. The conftest file contains the common test objects.

This is the 1st step for test cleaning. The next step will be to remove duplicate tests: only the DSM API version is different, assertions are the same. 