### PR TITLE
Always return live stream url using base host

### DIFF
--- a/src/synology_dsm/api/surveillance_station/__init__.py
+++ b/src/synology_dsm/api/surveillance_station/__init__.py
@@ -27,7 +27,9 @@ class SynoSurveillanceStation:
             if camera_data["id"] in self._cameras_by_id:
                 self._cameras_by_id[camera_data["id"]].update(camera_data)
             else:
-                self._cameras_by_id[camera_data["id"]] = SynoCamera(camera_data)
+                self._cameras_by_id[camera_data["id"]] = SynoCamera(
+                    camera_data, self._dsm._base_url
+                )
 
         for camera_id in self._cameras_by_id:
             self._cameras_by_id[camera_id].update_motion_detection(

--- a/src/synology_dsm/api/surveillance_station/camera.py
+++ b/src/synology_dsm/api/surveillance_station/camera.py
@@ -1,4 +1,7 @@
 """SurveillanceStation camera."""
+from urllib.parse import urlparse
+from urllib.parse import urlsplit
+
 from .const import MOTION_DETECTION_DISABLED
 from .const import RECORDING_STATUS
 
@@ -6,10 +9,10 @@ from .const import RECORDING_STATUS
 class SynoCamera:
     """An representation of a Synology SurveillanceStation camera."""
 
-    def __init__(self, data, live_view_data=None):
+    def __init__(self, data, base_url, live_view_data=None):
         """Initialize a Surveillance Station camera."""
         self._data = data
-        self.live_view = SynoCameraLiveView(live_view_data)
+        self.live_view = SynoCameraLiveView(live_view_data, urlsplit(base_url).hostname)
         self._motion_detection_enabled = None
 
     def update(self, data):
@@ -66,9 +69,18 @@ class SynoCamera:
 class SynoCameraLiveView:
     """An representation of a Synology SurveillanceStation camera live view."""
 
-    def __init__(self, data):
+    def __init__(self, data, base_url):
         """Initialize a Surveillance Station camera live view."""
+        self._base_url = base_url
         self.update(data)
+
+    def __format(self, url):
+        """Format live stream based on base url."""
+        parsed_url = urlparse(url)
+        new_url = parsed_url._replace(
+            netloc=self._base_url.join(parsed_url.netloc.rsplit(parsed_url.hostname, 1))
+        )
+        return new_url.geturl()
 
     def update(self, data):
         """Update the camera live view."""
@@ -77,24 +89,24 @@ class SynoCameraLiveView:
     @property
     def mjpeg_http(self):
         """Return the mjpeg stream (over http) path of the camera."""
-        return self._data["mjpegHttpPath"]
+        return self.__format(self._data["mjpegHttpPath"])
 
     @property
     def multicast(self):
         """Return the multi-cast path of the camera."""
-        return self._data["multicstPath"]
+        return self.__format(self._data["multicstPath"])
 
     @property
     def mxpeg_http(self):
         """Return the mxpeg stream path of the camera."""
-        return self._data["mxpegHttpPath"]
+        return self.__format(self._data["mxpegHttpPath"])
 
     @property
     def rtsp_http(self):
         """Return the RTSP stream (over http) path of the camera."""
-        return self._data["rtspOverHttpPath"]
+        return self.__format(self._data["rtspOverHttpPath"])
 
     @property
     def rtsp(self):
         """Return the RTSP stream path of the camera."""
-        return self._data["rtspPath"]
+        return self.__format(self._data["rtspPath"])

--- a/tests/test_synology_dsm.py
+++ b/tests/test_synology_dsm.py
@@ -904,7 +904,10 @@ class TestSynologyDSM(TestCase):
         assert self.api.surveillance_station.get_all_cameras()
         assert self.api.surveillance_station.get_camera(1)
         assert self.api.surveillance_station.get_camera_live_view_path(1)
-        assert self.api.surveillance_station.get_camera_live_view_path(1, "rtsp")
+        assert (
+            self.api.surveillance_station.get_camera_live_view_path(1, "rtsp")
+            == "rtsp://syno:stmkey1234567890@nas.mywebsite.me:554/Sms=1.unicast"
+        )
 
         # Motion detection
         assert self.api.surveillance_station.enable_motion_detection(1).get("success")


### PR DESCRIPTION
Synology DSM does not allow choosing which LAN interface (out of the two these devices typically support) is returned on the RTSP stream of the Surveillance Station software. There are numerous posts, both on Synology forums as well as on the Home Assistant community ([example](https://community.home-assistant.io/t/synology-dsm-camera-stream-not-working/234555)), where users seek workarounds on getting their cameras to work with the right IP/host.

I think the solution is much simpler and can be resolved with a simple invisible tweak: if the device is reachable - and we know it is otherwise entities would not have been created -, then always use that hostname or IP for the RTSP stream independently of what Synology Surveillance Station is returning.

This accommodates all sort of setups: from the basic IP in the same LAN to macvlans using containers where host communication must be done via a shim interface.
