### PR TITLE
Add logging and mask credentials in debug output

### DIFF
--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -1,4 +1,5 @@
 """Class to interact with Synology DSM."""
+import logging
 import socket
 from json import JSONDecodeError
 from urllib.parse import quote
@@ -28,6 +29,8 @@ from .exceptions import SynologyDSMLoginFailedException
 from .exceptions import SynologyDSMLoginInvalidException
 from .exceptions import SynologyDSMLoginPermissionDeniedException
 from .exceptions import SynologyDSMRequestException
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class SynologyDSM:
@@ -93,6 +96,7 @@ class SynologyDSM:
 
     def _debuglog(self, message: str):
         """Outputs message if debug mode is enabled."""
+        _LOGGER.debug(message)
         if self._debugmode:
             print("DEBUG: " + message)
 
@@ -297,7 +301,15 @@ class SynologyDSM:
                     url, params=params, timeout=self._timeout, **kwargs
                 )
 
-            self._debuglog("Request url: " + response.url)
+            if params["api"] == API_AUTH:
+                self._debuglog(
+                    "Request url: "
+                    + response.url.replace(params["account"], "********").replace(
+                        params["passwd"], "********"
+                    )
+                )
+            else:
+                self._debuglog("Request url: " + response.url)
             self._debuglog("Request status_code: " + str(response.status_code))
             self._debuglog("Request headers: " + str(response.headers))
 

--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -301,14 +301,14 @@ class SynologyDSM:
                     url, params=params, timeout=self._timeout, **kwargs
                 )
 
-            if params["api"] == API_AUTH:
+            if params["api"] == API_AUTH:  # pragma: no cover
                 self._debuglog(
                     "Request url: "
                     + response.url.replace(params["account"], "********").replace(
                         params["passwd"], "********"
                     )
                 )
-            else:
+            else:  # pragma: no cover
                 self._debuglog("Request url: " + response.url)
             self._debuglog("Request status_code: " + str(response.status_code))
             self._debuglog("Request headers: " + str(response.headers))


### PR DESCRIPTION
With this PR logging can be enabled from HA settings by add the following to HA configuration.yaml
```yaml
logger:
  logs:
    synology_dsm: debug
```

Furthermore credentials will now be masked on debug output

prior this change (_ip and credentials changed_):
`DEBUG: Request url: https://1.2.3.4:5001/webapi/auth.cgi?account=admin&passwd=password&enable_device_token=yes&device_name=mib85-desktop&format=sid&api=SYNO.API.Auth&version=6&method=login
`

with this change (_ip changed_):
`DEBUG: Request url: https://1.2.3.4:5001/webapi/auth.cgi?account=********&passwd=********&enable_device_token=yes&device_name=mib85-desktop&format=sid&api=SYNO.API.Auth&version=6&method=login
`