### PR TITLE
Use flake8 from repo for pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,6 @@ repos:
         language: system
         types: [text]
         stages: [commit, push, manual]
-      - id: flake8
-        name: flake8
-        entry: flake8
-        language: system
-        types: [python]
-        require_serial: true
       - id: reorder-python-imports
         name: Reorder python imports
         entry: reorder-python-imports
@@ -49,3 +43,10 @@ repos:
     rev: v2.2.1
     hooks:
       - id: prettier
+  - repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        language: system
+        types: [python]
+        require_serial: true


### PR DESCRIPTION
...since it is removed from local available pre-commit hooks in pre-commit 4.0.0

this is pre-required for #78