### PR TITLE
Adds session_name to login

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,9 +51,12 @@ Constructor
         timeout=None,
         device_token=None,
         debugmode=False,
+        session_name=None
     )
 
 ``device_token`` should be added when using a two-step authentication account, otherwise DSM will ask to login with a One Time Password (OTP) and requests will fail (see the login section for more details).
+
+``session_name`` should be added when using a non admin account.
 
 Default ``timeout`` is 10 seconds.
 

--- a/src/synology_dsm/synology_dsm.py
+++ b/src/synology_dsm/synology_dsm.py
@@ -53,6 +53,7 @@ class SynologyDSM:
         timeout: int = None,
         device_token: str = None,
         debugmode: bool = False,
+        session_name: str = None,
     ):
         """Constructor method."""
         self.username = username
@@ -66,6 +67,7 @@ class SynologyDSM:
         self._session.verify = self._verify
 
         # Login
+        self.session_name = session_name
         self._session_id = None
         self._syno_token = None
         self._device_token = device_token
@@ -151,6 +153,9 @@ class SynologyDSM:
             "device_name": socket.gethostname(),
             "format": "sid",
         }
+
+        if self.session_name is not None:
+            params['session'] = self.session_name
 
         if otp_code:
             params["otp_code"] = otp_code


### PR DESCRIPTION
I have been working on a Moments API integration for DSM 6 and will eventually move to Photos for DSM 7.  I am using a non-admin user and was failing login auth. I found that I needed to provide the optional session name during login for this user to be able to login. I have not been able to find a solid list of available session names but the ones that I have found to work thus far are: 'FileStation', 'NoteStation', and 'Chat' if they are installed and the user has access to them. I have been using FileStation for my user and then all calls for the Moments api's (ex: SYNO.PhotoTeam.Browse.Item) work perfectly using the returned _sid from login. It seems that 'Photo', 'PhotoStation', 'PhotoTeam', or 'Moments' are not valid session_names.