### PR TITLE
add disk utilization, read, and write metrics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,9 @@ The ``SynologyDSM`` class can also ``update()`` all APIs at once.
     print("Memory Use:      " + str(api.utilisation.memory_real_usage) + " %")
     print("Net Up:          " + str(api.utilisation.network_up()))
     print("Net Down:        " + str(api.utilisation.network_down()))
+    print("Disk Util:       " + str(api.utilisation.disk_utilization()) + " %")
+    print("Disk Read:       " + str(api.utilisation.disk_read()))
+    print("Disk Write:      " + str(api.utilisation.disk_write()))
     print("--")
 
     print("=== Storage ===")

--- a/src/synology_dsm/api/core/utilization.py
+++ b/src/synology_dsm/api/core/utilization.py
@@ -167,3 +167,45 @@ class SynoCoreUtilization:
                 return SynoFormatHelper.bytes_to_readable(return_data)
             return return_data
         return None
+
+    @property
+    def disk(self):
+        """Gets disk utilization."""
+        return self._data.get("disk", {})
+
+    def _get_disk(self, disk_id):
+        """Function to get specific disk (sata1, total, etc)."""
+        if disk_id == "total":
+            return self.disk.get("total", None)
+        else:
+            for disk in self.disk.get("disk", []):
+                if disk["device"] == disk_id:
+                    return disk
+        return None
+
+    def disk_utilization(self):
+        """Total percent of disk being used."""
+        disk = self._get_disk("total")
+        if disk:
+            return int(disk["utilization"])
+        return None
+
+    def disk_read(self, human_readable=False):
+        """Total bytes being read from disk."""
+        disk = self._get_disk("total")
+        if disk:
+            return_data = int(disk["read_byte"])
+            if human_readable:
+                return SynoFormatHelper.bytes_to_readable(return_data)
+            return return_data
+        return None
+
+    def disk_write(self, human_readable=False):
+        """Total bytes being written to disk."""
+        disk = self._get_disk("total")
+        if disk:
+            return_data = int(disk["write_byte"])
+            if human_readable:
+                return SynoFormatHelper.bytes_to_readable(return_data)
+            return return_data
+        return None

--- a/tests/test_synology_dsm.py
+++ b/tests/test_synology_dsm.py
@@ -583,3 +583,13 @@ class TestSynologyDSM:
         assert dsm.utilisation.network_up(True)
         assert dsm.utilisation.network_down()
         assert dsm.utilisation.network_down(True)
+
+    def test_utilisation_disk(self, dsm):
+        """Test utilisation disk."""
+        dsm.utilisation.update()
+        assert dsm.utilisation.disk
+        assert dsm.utilisation.disk_utilization()
+        assert dsm.utilisation.disk_read()
+        assert dsm.utilisation.disk_read(True)
+        assert dsm.utilisation.disk_write()
+        assert dsm.utilisation.disk_write(True)


### PR DESCRIPTION
This PR adds functions to pull the disk-related metrics from the utilization API data. This includes the total utilization as a percentage, plus the total read and write bytes. The end goal is to expose this data for Home Assistant's Synology integration.

I've also added these metrics to the README utilization example and added a unit test.